### PR TITLE
(fix) Use HTTPS for demo url [Fixes #23].

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ JuliusJS
 
 > A speech recognition library for the web
 
-Try the [live demo.](http://zzmp.github.io/juliusjs/) 
+Try the [live demo.](https://zzmp.github.io/juliusjs/)
 
 JuliusJS is an opinionated port of Julius to JavaScript. <br>
 It __actively listens to the user to transcribe what they are saying__ through a callback.


### PR DESCRIPTION
Fixes the demo page not working if loaded from an insecure endpoint.

![](https://www.dropbox.com/s/7jdwm4kmydcp1ia/Screenshot%202016-05-11%2011.03.17.png?dl=1)
